### PR TITLE
Adding fix on waitForNewtab method

### DIFF
--- a/helpers/utils/wait-helper.js
+++ b/helpers/utils/wait-helper.js
@@ -234,7 +234,6 @@ class WaitHelper {
      *  Waits for a new tab to be loaded by considering an increment of 1 to the list of window handles if
      *  no parameter is sent then the method will wait for the second tab to be open
      *  Handles need to be sent as an integer number e.g. await browser.getWindowHandles().length
-     * 
      * @param {number} [handles = 1] - Number of window handles open at the moment of waiting for a new tab
      * @param {number} [timeout = timeouts.S5] - time to wait
      */

--- a/helpers/utils/wait-helper.js
+++ b/helpers/utils/wait-helper.js
@@ -241,9 +241,11 @@ class WaitHelper {
     async waitForNewTab(handles = 1, timeout = timeouts.S5){
 		await browser.waitUntil(
 			async function () {
+			async function () {
 				const openTabs = await browser.getWindowHandles();
 				return (openTabs.length > handles); },
 			{
+				timeout: timeout,
 				timeout: timeout,
 				timeoutMsg: 'Failed while waiting for New Tab'
 			}
@@ -256,10 +258,15 @@ class WaitHelper {
      * 
      */
     async waitForAlert(timeout = timeouts.S3){
+    async waitForAlert(timeout = timeouts.S3){
 		await browser.waitUntil(
+			async function (){ 
+                return ( await browser.isAlertOpen() ) ; 
+            },
 			async function (){ 
                 return (await browser.isAlertOpen()); },
 			{
+				timeout: timeout,
 				timeout: timeout,
 				timeoutMsg: 'Failed while waiting for Alert to show up'
 			}

--- a/helpers/utils/wait-helper.js
+++ b/helpers/utils/wait-helper.js
@@ -241,11 +241,9 @@ class WaitHelper {
     async waitForNewTab(handles = 1, timeout = timeouts.S5){
 		await browser.waitUntil(
 			async function () {
-			async function () {
 				const openTabs = await browser.getWindowHandles();
 				return (openTabs.length > handles); },
 			{
-				timeout: timeout,
 				timeout: timeout,
 				timeoutMsg: 'Failed while waiting for New Tab'
 			}
@@ -264,9 +262,9 @@ class WaitHelper {
                 return ( await browser.isAlertOpen() ) ; 
             },
 			async function (){ 
-                return (await browser.isAlertOpen()); },
+                return ( await browser.isAlertOpen() ) ; 
+            },
 			{
-				timeout: timeout,
 				timeout: timeout,
 				timeoutMsg: 'Failed while waiting for Alert to show up'
 			}

--- a/helpers/utils/wait-helper.js
+++ b/helpers/utils/wait-helper.js
@@ -236,14 +236,15 @@ class WaitHelper {
      *  Handles need to be sent as an integer number e.g. await browser.getWindowHandles().length
      * 
      * @param {number} [handles = 1] - Number of window handles open at the moment of waiting for a new tab
+     * @param {number} [timeout = timeouts.S5] - time to wait
      */
-    async waitForNewTab(handles = 1){
+    async waitForNewTab(handles = 1, timeout = timeouts.S5){
 		await browser.waitUntil(
-			async function (){
+			async function () {
 				const openTabs = await browser.getWindowHandles();
 				return ( openTabs.length > handles ) ; },
 			{
-				timeout: timeouts.S5,
+				timeout: timeout,
 				timeoutMsg: 'Failed while waiting for New Tab'
 			}
 		);
@@ -251,13 +252,16 @@ class WaitHelper {
 
     /**
      * Waits for an Alert to be displayed
+     * @param {number} [timeout = timeouts.S3] - time to wait
      * 
      */
-    async waitForAlert(){
+    async waitForAlert(timeout = timeouts.S3){
 		await browser.waitUntil(
-			async function (){ return ( await browser.isAlertOpen() ) ; },
+			async function (){ 
+                return ( await browser.isAlertOpen() ) ; 
+            },
 			{
-				timeout: timeouts.S3,
+				timeout: timeout,
 				timeoutMsg: 'Failed while waiting for Alert to show up'
 			}
 		);

--- a/helpers/utils/wait-helper.js
+++ b/helpers/utils/wait-helper.js
@@ -256,11 +256,16 @@ class WaitHelper {
      * 
      */
     async waitForAlert(timeout = timeouts.S3){
+    async waitForAlert(timeout = timeouts.S3){
 		await browser.waitUntil(
 			async function (){ 
                 return ( await browser.isAlertOpen() ) ; 
             },
+			async function (){ 
+                return ( await browser.isAlertOpen() ) ; 
+            },
 			{
+				timeout: timeout,
 				timeout: timeout,
 				timeoutMsg: 'Failed while waiting for Alert to show up'
 			}

--- a/helpers/utils/wait-helper.js
+++ b/helpers/utils/wait-helper.js
@@ -256,14 +256,9 @@ class WaitHelper {
      * 
      */
     async waitForAlert(timeout = timeouts.S3){
-    async waitForAlert(timeout = timeouts.S3){
 		await browser.waitUntil(
 			async function (){ 
-                return ( await browser.isAlertOpen() ) ; 
-            },
-			async function (){ 
-                return ( await browser.isAlertOpen() ) ; 
-            },
+                return (await browser.isAlertOpen()); },
 			{
 				timeout: timeout,
 				timeoutMsg: 'Failed while waiting for Alert to show up'

--- a/helpers/utils/wait-helper.js
+++ b/helpers/utils/wait-helper.js
@@ -231,14 +231,17 @@ class WaitHelper {
     }
 
     /**
-     *  Waits for a new tab to be loaded by considering an increment of 1 to the list of window handles
+     *  Waits for a new tab to be loaded by considering an increment of 1 to the list of window handles if
+     *  no parameter is sent then the method will wait for the second tab to be open
+     *  Handles need to be sent as an integer number e.g. await browser.getWindowHandles().length
      * 
+     * @param {number} [handles = 1] - Number of window handles open at the moment of waiting for a new tab
      */
-    async waitForNewTab(){
+    async waitForNewTab(handles = 1){
 		await browser.waitUntil(
 			async function (){
 				const openTabs = await browser.getWindowHandles();
-				return ( openTabs.length > 1 ) ; },
+				return ( openTabs.length > handles ) ; },
 			{
 				timeout: timeouts.S5,
 				timeoutMsg: 'Failed while waiting for New Tab'

--- a/helpers/utils/wait-helper.js
+++ b/helpers/utils/wait-helper.js
@@ -256,7 +256,6 @@ class WaitHelper {
      * 
      */
     async waitForAlert(timeout = timeouts.S3){
-    async waitForAlert(timeout = timeouts.S3){
 		await browser.waitUntil(
 			async function (){ 
                 return ( await browser.isAlertOpen() ) ; 

--- a/helpers/utils/wait-helper.js
+++ b/helpers/utils/wait-helper.js
@@ -242,7 +242,7 @@ class WaitHelper {
 		await browser.waitUntil(
 			async function () {
 				const openTabs = await browser.getWindowHandles();
-				return ( openTabs.length > handles ) ; },
+				return (openTabs.length > handles); },
 			{
 				timeout: timeout,
 				timeoutMsg: 'Failed while waiting for New Tab'
@@ -258,13 +258,8 @@ class WaitHelper {
     async waitForAlert(timeout = timeouts.S3){
 		await browser.waitUntil(
 			async function (){ 
-                return ( await browser.isAlertOpen() ) ; 
-            },
-			async function (){ 
-                return ( await browser.isAlertOpen() ) ; 
-            },
+                return (await browser.isAlertOpen()); },
 			{
-				timeout: timeout,
 				timeout: timeout,
 				timeoutMsg: 'Failed while waiting for Alert to show up'
 			}


### PR DESCRIPTION
Adding fix on:

- waitForNewTab method in order to handle more scenarios instead of only waiting for the second tab